### PR TITLE
feat: add Specialized Data APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Managed services that turn URLs into LLM-ready Markdown or JSON. JS rendering, p
 - [Expand.ai](https://www.expand.ai/) - Turns any website into a type-safe API. Paid.
 - [Reworkd](https://reworkd.ai/) - Agentic AI for no-code structured extraction. Paid.
 
+## Specialized Data APIs
+
+Focused scrapers for specific platforms or data types — not general-purpose crawlers.
+
+- [gmapsscraper.io](https://gmapsscraper.io) — Google Maps lead extraction API; returns business names, phones, emails, addresses and more. Credit-based, free trial available.
+
 ## Browser Infrastructure for AI
 
 Headless browsers designed for AI agents and scrapers.


### PR DESCRIPTION
## What this adds

A new **Specialized Data APIs** section between "Hosted APIs" and "Browser Infrastructure for AI" — for APIs that extract data from a specific platform rather than crawling arbitrary URLs.

The current Hosted APIs section covers general-purpose scrapers (Firecrawl, Jina, Diffbot, etc.). There's a growing category of specialized extraction APIs that don't fit the general-purpose mold but are highly valuable to AI/data workflows.

## Added entry

- [gmapsscraper.io](https://gmapsscraper.io) — Google Maps lead extraction API; returns business names, phones, emails, addresses and more. Credit-based, free trial available.

This is useful for anyone building lead generation pipelines, local SEO tools, or market research agents that need structured Google Maps data.

Happy to adjust placement or wording!